### PR TITLE
Headline component 

### DIFF
--- a/core/src/main/java/com/adobe/aem/gia/project/core/models/Headline.java
+++ b/core/src/main/java/com/adobe/aem/gia/project/core/models/Headline.java
@@ -1,0 +1,35 @@
+package com.adobe.aem.gia.project.core.models;
+
+import org.osgi.annotation.versioning.ConsumerType;
+
+
+/**
+ * Defines the {@code Headline Component} Sling Model used for the page and
+ * section headings
+ */
+@ConsumerType
+public interface Headline   {
+
+    /**
+     * Returns the title text
+     * 
+     * @return
+     * @throws IllegalStateException if title is empty or null
+     */
+    public String getTitle() throws IllegalStateException ;
+
+    /**
+     * Returns the headline component authored ID
+     * 
+     * @return
+     */
+    public String getId() throws IllegalStateException;
+
+    /**
+     * Returns the heading element type
+     * 
+     * @return heading type h1 - h6
+     */
+    public String getType() throws IllegalStateException;
+
+}

--- a/core/src/main/java/com/adobe/aem/gia/project/core/models/HeadlineModel.java
+++ b/core/src/main/java/com/adobe/aem/gia/project/core/models/HeadlineModel.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2015 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.adobe.aem.gia.project.core.models;
+
+import static org.apache.sling.api.resource.ResourceResolver.PROPERTY_RESOURCE_TYPE;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.models.annotations.Default;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+
+import java.util.Optional;
+
+@Model(adaptables = Resource.class)
+public class HeadlineModel {
+
+    @ValueMapValue(name=PROPERTY_RESOURCE_TYPE, injectionStrategy=InjectionStrategy.OPTIONAL)
+    @Default(values="No resourceType")
+    protected String resourceType;
+
+
+    private String title;
+
+    private String element;
+
+    private String className;
+
+    private Boolean hasAccent;
+
+}

--- a/core/src/main/java/com/adobe/aem/gia/project/core/models/impl/HeadlineModelImpl.java
+++ b/core/src/main/java/com/adobe/aem/gia/project/core/models/impl/HeadlineModelImpl.java
@@ -1,0 +1,45 @@
+package com.adobe.aem.gia.project.core.models.impl;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+
+import com.adobe.aem.gia.project.core.models.Headline;
+import com.adobe.xfa.ut.StringUtils;
+
+@Model(adaptables = { SlingHttpServletRequest.class,
+        Resource.class }, adapters = Headline.class, resourceType = HeadlineModelImpl.RESOURCE_TYPE, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
+public class HeadlineModelImpl implements Headline {
+    static final String RESOURCE_TYPE = "aem-gia-project/components/headline";
+
+    @ValueMapValue()
+    private String title;
+
+    @ValueMapValue()
+    private String id;
+
+    @ValueMapValue()
+    private String type;
+
+    
+    @Override
+    public String getTitle() throws IllegalStateException {
+        if (StringUtils.isEmpty(title)) {
+            throw new IllegalStateException("Title cannot be empty");
+        }
+        return title;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+}

--- a/ui.apps/src/main/content/jcr_root/apps/gia-test/clientlibs/clientlib-author/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/gia-test/clientlibs/clientlib-author/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[gia-test.author]"
+    cssProcessor="[default:none,min:none]"
+    jsProcessor="[default:none,min:none]"
+    allowProxy="{Boolean}true"/>

--- a/ui.apps/src/main/content/jcr_root/apps/gia-test/clientlibs/clientlib-author/css.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/gia-test/clientlibs/clientlib-author/css.txt
@@ -1,0 +1,3 @@
+#base=css
+
+author.css

--- a/ui.apps/src/main/content/jcr_root/apps/gia-test/clientlibs/clientlib-author/css/author.css
+++ b/ui.apps/src/main/content/jcr_root/apps/gia-test/clientlibs/clientlib-author/css/author.css
@@ -1,0 +1,1 @@
+._coral-Dialog-title{font-size:24px}

--- a/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/.content.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" 
+    xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Headline"
+    cq:icon = "abc"
+    jcr:description ="Page and section heading"
+    sling:resourceSuperType="core/wcm/components/title/v3/title"
+    componentGroup="AEM Gia project - Content">
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/.content.xml
@@ -7,5 +7,5 @@
     cq:icon = "abc"
     jcr:description ="Page and section heading"
     sling:resourceSuperType="core/wcm/components/title/v3/title"
-    componentGroup="AEM Gia project - Content">
+    componentGroup="Gia Sites Project - Content">
 </jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/README.md
+++ b/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/README.md
@@ -2,4 +2,33 @@
 
 Extends the Title Core component 
 
-## Settings
+## Configuration
+
+### Content Tab
+
+- `Text`: The actual headline text
+- `ID`: An authorable ID for the headline
+
+### Display tab
+
+- `Element`: A dropdown selection to set the HTML Heading element from h1-h6. The element does not alter the styles.
+
+## Styles
+
+The headline component accepts the following styles settings:
+
+### Heading size
+
+| Style name  | Class name   | 
+|-------------|--------------|
+| SM  |   heading--sm  |   
+| MD  |   heading--md |   
+| LG  |   heading--lg |   
+
+
+### Accent
+
+| Style name  | Class name   | 
+|-------------|--------------|
+| Accent      | heading--accent|   
+

--- a/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/README.md
+++ b/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/README.md
@@ -1,0 +1,5 @@
+# Headline component 
+
+Extends the Title Core component 
+
+## Settings

--- a/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/_cq_dialog/.content.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    xmlns:nt="http://www.jcp.org/jcr/nt/1.0" jcr:primaryType="nt:unstructured"
+    jcr:title="Headline settings" sling:resourceType="cq/gui/components/authoring/dialog"
+    mode="edit" 
+    extraClientlibs="[aem-gia-project.author]"
+    helpPath="style-guide.html#headline">
+    <content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/foundation/container">
+        <layout
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/foundation/layouts/tabs"
+            type="nav"/>
+        <items jcr:primaryType="nt:unstructured"  sling:hideChildren="*">
+            <content
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Content"
+                sling:resourceType="granite/ui/components/foundation/section">
+                <layout
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"
+                    margin="{Boolean}false"/>
+                <items jcr:primaryType="nt:unstructured">
+                    <column
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/foundation/container">
+                        <items jcr:primaryType="nt:unstructured">
+                            <title
+                                jcr:primaryType="nt:unstructured"
+                                fieldDescription="Title"
+                                required="{Boolean}true"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                fieldLabel="Title"
+                                name="./title"/>
+                            <id
+                                jcr:primaryType="nt:unstructured"
+                                fieldDescription="ID"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                fieldLabel="ID"
+                                name="./id"/>
+                            </items>
+                    </column>
+                </items>
+            </content>
+            <display
+                jcr:primaryType="nt:unstructured"
+                jcr:title="Display"
+                sling:resourceType="granite/ui/components/foundation/section">
+                <layout
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"
+                    margin="{Boolean}true"/>
+                <items jcr:primaryType="nt:unstructured">
+                    <column
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/foundation/container">
+                        <items jcr:primaryType="nt:unstructured">
+                            <!-- Types using core component datasource -->
+                            <types
+                                jcr:primaryType="nt:unstructured"
+                                fieldDescription="Test"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                fieldLabel="Heading Type"
+                                name="./type">
+                                 <items jcr:primaryType="nt:unstructured">
+                                    <h1
+                                        jcr:primaryType="nt:unstructured"
+                                        text="H1"
+                                        value="h1"/>
+                                    <h2
+                                        jcr:primaryType="nt:unstructured"
+                                        text="H2"
+                                        value="h2"/>
+                                    <h3
+                                        jcr:primaryType="nt:unstructured"
+                                        text="H3"
+                                        value="h3"/>
+                                    <h4
+                                        jcr:primaryType="nt:unstructured"
+                                        text="H4"
+                                        value="h4"/>
+                                    <h5
+                                        jcr:primaryType="nt:unstructured"
+                                        text="H5"
+                                        value="h5"/>
+                                    <h6
+                                        jcr:primaryType="nt:unstructured"
+                                        text="H6"
+                                        value="h6"/>
+                                </items>
+                                <!-- This datasource didn't work, I wanted to use the allowed types that are set from the Component's policies -->
+                                <!-- <datasource
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="/libs/core/wcm/components/title/v3/datasource/allowedTypes"/> -->
+                            </types>
+                    
+                        </items>
+                    </column>
+                </items>
+            </display>
+        </items>
+    </content>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/headline.html
+++ b/ui.apps/src/main/content/jcr_root/apps/gia-test/components/headline/headline.html
@@ -1,0 +1,14 @@
+
+<!-- Models -->
+<sly data-sly-use.model="com.adobe.aem.gia.project.core.models.Headline"
+    data-sly-use.template="core/wcm/components/commons/v1/templates.html"></sly>
+
+<!-- Constants-->
+<sly data-sly-set.isEmpty="${!model.title}" data-sly-set.id="${model.id}"> </sly>
+
+<!-- Component -->
+<div class="cmp-headline"  data-sly-test="${!isEmpty}" data-cmp-is="headline" id="${id}">
+    <h1 class="cmp-headline__text" data-sly-element="${model.type}"> ${model.title}</h1>
+</div>
+
+<sly data-sly-call="${template.placeholder @ isEmpty=isEmpty, classAppend='cmp-headline'}"></sly>

--- a/ui.apps/src/main/content/jcr_root/apps/gia-test/components/helloworld/helloworld.html
+++ b/ui.apps/src/main/content/jcr_root/apps/gia-test/components/helloworld/helloworld.html
@@ -14,7 +14,7 @@
     limitations under the License.
 */-->
 <div class="cmp-helloworld" data-cmp-is="helloworld">
-    <h2 class="cmp-helloworld__title">Hello World Component</h2>
+    <h2 class="cmp-helloworld__title">Hello World Component - Playground project</h2>
     <div class="cmp-helloworld__item" data-sly-test="${properties.text}">
         <p class="cmp-helloworld__item-label">Text property:</p>
         <pre class="cmp-helloworld__item-output" data-cmp-hook-helloworld="property">${properties.text}</pre>

--- a/ui.frontend/src/main/webpack/author/styles/dialog.scss
+++ b/ui.frontend/src/main/webpack/author/styles/dialog.scss
@@ -1,3 +1,3 @@
-.class-test { 
+._coral-Dialog-title { 
     font-size: 24px;
 }

--- a/ui.frontend/src/main/webpack/components/_headline.scss
+++ b/ui.frontend/src/main/webpack/components/_headline.scss
@@ -1,0 +1,40 @@
+.cmp-headline,
+.cmp-headline__text:is(h1, h2, h3,h4, h5, h6){
+    margin: 0;
+    padding: 0;
+    font-size: 100%;
+    font-family: $font-headline-font-family;
+}
+
+.headline--sm {
+    font-size: $font-headline-size--sm;
+    line-height:  2.5em;
+
+}
+
+.headline--md {
+    font-size: $font-headline-size--md;
+    line-height:  3em;
+
+}
+
+.headline--lg {
+    font-size: $font-headline-size--lg;
+    line-height:  3.5em;
+
+}
+
+.headline--accent {
+    position: relative;
+}
+
+.headline--accent::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 15%;
+    height: 6px;
+    background-color: $color-accent;
+    transform: translateY(-50%);
+}

--- a/ui.frontend/src/main/webpack/site/_variables.scss
+++ b/ui.frontend/src/main/webpack/site/_variables.scss
@@ -1,9 +1,16 @@
 
 //== Font
 
-$font-family:           "Helvetica Neue", Helvetica, Arial, sans-serif;
-$font-size:             16px;
+$font-family:                   "Helvetica Neue", Helvetica, Arial, sans-serif;
+$font-headline-font-family:     "Gill Sans", sans-serif;         
+$font-size:                  16px;
 $font-height:           1.5;
+
+// Typography 
+$font-headline-size--sm: 18px;
+$font-headline-size--md: 30px;
+$font-headline-size--lg: 42px;
+
 
 //== Color
 
@@ -11,6 +18,7 @@ $font-height:           1.5;
 $color-foreground:      #202020;
 $color-background:      #ECECEC;
 $color-link:            #2020E0;
+$color-accent:  #058743;
 
 // Dark mode
 $color-foreground-dark: invert($color-foreground);


### PR DESCRIPTION
# Summary

This MR does the following: 

- Creates a Headline component
- Sets style classes for sizing and accent to be used by the Style policies. 
- The headline is not responsive yet. 
- Creates the sling model, impl, HTL, client library .scss
- It's part of the site clientlib 

# Testing steps

1. Pull this MR and build. 
2. Update the Page template to allow the new Component 
3. Update the policies to add the class names. 
4. Verify the following: 

- [x] When SM selected the font-size should be headline --sm
- [x] When MD selected the font-size should be headline --md
- [x] When LG selected the font-size should be set to headline--lg.
- [x] When Accent is selected, there should be an accent underline visible.  
- [x] When authoring the Heading element and ID, the element and IDs are set correctly in the published view


# Demo

Styles tab: 

<img width="1238" alt="Screenshot 2025-04-22 at 3 14 30 PM" src="https://github.com/user-attachments/assets/6542b869-10b9-485e-af5f-2892fe69db35" />

![Screenshot 2025-04-23 at 10 59 44 AM](https://github.com/user-attachments/assets/14eacd43-dc42-4972-9c73-d7d30e1fa669)

